### PR TITLE
Feature template envvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,6 @@ cat data.yaml | simplate --input-schema-file schema.json template.tmpl -
 ## Notes
 
 - Templates should conform to the Go `text/template` format.
+  - You can access the values of environment variables using the `env` function, like this: `{{ env "HOME" }}`.
 - YAML input should be properly structured and optionally validated using a JSON Schema.
 - Use `-` to read input from stdin if the second positional argument is not provided.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,13 @@ func Execute() error {
 
 func runE(cmd *cobra.Command, args []string) error {
 
+	if len(args) < 1 {
+		return fmt.Errorf("no template file provided")
+	}
+	if len(args) > 2 {
+		return fmt.Errorf("too many arguments provided")
+	}
+
 	templateFile := args[0] // Template file is the first required arg
 
 	// --- Determine Input Source ---

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestCmd(args ...string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "simplate",
+	}
+	cmd.SetArgs(args)
+	return cmd
+}
+
+func Test_runE_NoArgs(t *testing.T) {
+	cmd := newTestCmd()
+	err := runE(cmd, []string{})
+	if err == nil || !strings.Contains(err.Error(), "no template file provided") {
+		t.Errorf("expected error for no args, got: %v", err)
+	}
+}
+
+func Test_runE_InputContentFlag(t *testing.T) {
+	inputContent = "foo: bar"
+	defer func() { inputContent = "" }()
+
+	tmp, err := os.CreateTemp("", "tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.WriteString("{{.foo}}")
+	tmp.Close()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := newTestCmd(tmp.Name())
+	err = runE(cmd, []string{tmp.Name()})
+
+	w.Close()
+	os.Stdout = oldStdout
+	out, _ := io.ReadAll(r)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "bar" {
+		t.Errorf("expected output 'bar', got '%s'", string(out))
+	}
+}
+
+func Test_runE_TemplateFileNotFound(t *testing.T) {
+	inputContent = "foo: bar"
+	defer func() { inputContent = "" }()
+	cmd := newTestCmd("notfound.tmpl")
+	err := runE(cmd, []string{"notfound.tmpl"})
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected file not found error, got: %v", err)
+	}
+}
+
+func Test_runE_EmptyInputContent(t *testing.T) {
+	inputContent = ""
+	defer func() { inputContent = "" }()
+	cmd := newTestCmd("file.tmpl")
+	err := runE(cmd, []string{"file.tmpl"})
+	if err == nil || !strings.Contains(err.Error(), "no data provided") {
+		t.Errorf("expected error for empty input content, got: %v", err)
+	}
+}
+
+func Test_runE_FileArgInput(t *testing.T) {
+	// Create YAML data file
+	dataFile, err := os.CreateTemp("", "data.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(dataFile.Name())
+	dataFile.WriteString("foo: filebar")
+	dataFile.Close()
+
+	// Create template file
+	tmplFile, err := os.CreateTemp("", "tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmplFile.Name())
+	tmplFile.WriteString("{{.foo}}")
+	tmplFile.Close()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := newTestCmd(tmplFile.Name(), dataFile.Name())
+	err = runE(cmd, []string{tmplFile.Name(), dataFile.Name()})
+
+	w.Close()
+	os.Stdout = oldStdout
+	out, _ := io.ReadAll(r)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "filebar" {
+		t.Errorf("expected output 'filebar', got '%s'", string(out))
+	}
+}
+
+func Test_CLI_Execute_WithInputContentFlag(t *testing.T) {
+	// Create template file
+	tmplFile, err := os.CreateTemp("", "tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmplFile.Name())
+	tmplFile.WriteString("{{.foo}}")
+	tmplFile.Close()
+
+	// Save and restore os.Args
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	os.Args = []string{"simplate", "-c", "foo: cli", tmplFile.Name()}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err = Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+	out, _ := io.ReadAll(r)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "cli" {
+		t.Errorf("expected output 'cli', got '%s'", string(out))
+	}
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3,12 +3,17 @@ package generator
 import (
 	"fmt"
 	"io"
+	"os"
 	"text/template"
 )
 
+var funcMap = template.FuncMap{
+	"env": os.Getenv,
+}
+
 func Generate(input any, templateContent []byte, output io.Writer) error {
 
-	tmpl, err := template.New("generator").Parse(string(templateContent))
+	tmpl, err := template.New("generator").Funcs(funcMap).Parse(string(templateContent))
 	if err != nil {
 		return fmt.Errorf("failed to parse template: %w", err)
 	}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1,0 +1,61 @@
+package generator
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGenerate_ValidTemplate(t *testing.T) {
+	templateContent := []byte("Hello, {{.Name}}! Env: {{env \"FOO_ENV\"}}")
+	input := map[string]interface{}{"Name": "World"}
+	os.Setenv("FOO_ENV", "bar")
+	defer os.Unsetenv("FOO_ENV")
+
+	var buf bytes.Buffer
+	err := Generate(input, templateContent, &buf)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "Hello, World!") || !strings.Contains(output, "Env: bar") {
+		t.Errorf("unexpected output: %q", output)
+	}
+}
+
+func TestGenerate_InvalidTemplate(t *testing.T) {
+	templateContent := []byte("Hello, {{.Name") // missing closing }}
+	input := map[string]interface{}{"Name": "World"}
+	var buf bytes.Buffer
+	err := Generate(input, templateContent, &buf)
+	if err == nil {
+		t.Fatal("expected error for invalid template, got nil")
+	}
+}
+
+func TestGenerate_MissingVariable(t *testing.T) {
+	templateContent := []byte("Hello, {{.Missing}}!")
+	input := map[string]interface{}{"Name": "World"}
+	var buf bytes.Buffer
+	err := Generate(input, templateContent, &buf)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "<no value>") {
+		t.Errorf("expected '<no value>' in output, got %q", output)
+	}
+}
+
+func TestGenerate_NilInput(t *testing.T) {
+	templateContent := []byte("Static content only")
+	var buf bytes.Buffer
+	err := Generate(nil, templateContent, &buf)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if buf.String() != "Static content only" {
+		t.Errorf("unexpected output: %q", buf.String())
+	}
+}

--- a/internal/loader/yaml_loader_test.go
+++ b/internal/loader/yaml_loader_test.go
@@ -1,0 +1,48 @@
+package loader
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLoadYaml_Success(t *testing.T) {
+	input := []byte("key: value\nnumber: 42")
+	expected := map[string]interface{}{
+		"key":    "value",
+		"number": 42,
+	}
+
+	result, err := LoadYaml(input)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// The YAML library unmarshals into map[string]interface{}
+	resMap, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map[string]interface{}, got %T", result)
+	}
+
+	if !reflect.DeepEqual(resMap, expected) {
+		t.Errorf("expected %v, got %v", expected, resMap)
+	}
+}
+
+func TestLoadYaml_InvalidYAML(t *testing.T) {
+	input := []byte("key: value\n  -- invalid: hello")
+	_, err := LoadYaml(input)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestLoadYaml_EmptyInput(t *testing.T) {
+	input := []byte("")
+	result, err := LoadYaml(input)
+	if err != nil {
+		t.Fatalf("expected no error for empty input, got %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result for empty input, got %v", result)
+	}
+}

--- a/internal/validator/yaml_validator_test.go
+++ b/internal/validator/yaml_validator_test.go
@@ -1,0 +1,57 @@
+package validator
+
+import (
+	"testing"
+)
+
+func TestValidateYamlWithSchema_Valid(t *testing.T) {
+	schema := []byte(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"},
+			"age": {"type": "integer"}
+		},
+		"required": ["name", "age"]
+	}`)
+	data := map[string]interface{}{
+		"name": "Alice",
+		"age":  30,
+	}
+
+	err := ValidateYamlWithSchema(data, schema)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateYamlWithSchema_InvalidData(t *testing.T) {
+	schema := []byte(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"},
+			"age": {"type": "integer"}
+		},
+		"required": ["name", "age"]
+	}`)
+	data := map[string]interface{}{
+		"name": "Bob",
+		"age":  "not-an-integer",
+	}
+
+	err := ValidateYamlWithSchema(data, schema)
+	if err == nil {
+		t.Fatal("expected error for invalid data, got nil")
+	}
+}
+
+func TestValidateYamlWithSchema_InvalidSchema(t *testing.T) {
+	invalidSchema := []byte(`{ "type": "object", "properties": { "foo": { "type": "unknown" } } }`)
+	data := map[string]interface{}{
+		"foo": "bar",
+	}
+
+	err := ValidateYamlWithSchema(data, invalidSchema)
+	if err == nil {
+		t.Fatal("expected error for invalid schema, got nil")
+	}
+}


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across multiple areas of the project, including template functionality, input validation, and testing. The key changes involve adding support for environment variables in templates, improving input argument validation, and expanding test coverage for template generation, YAML loading, and schema validation.

### Template enhancements:
* Added support for accessing environment variables in templates using the `env` function. This was implemented by adding a `template.FuncMap` in `internal/generator/generator.go` and updating the `Generate` function to use it.
* Updated the `README.md` to document the new `env` function usage.

### Input validation improvements:
* Added argument validation in `cmd/root.go` to ensure the correct number of arguments are provided to the CLI, returning appropriate error messages for missing or excessive arguments.

### Expanded test coverage:
* Added unit tests for the `Generate` function to validate template rendering, including cases for valid templates, invalid templates, missing variables, and static content.
* Introduced tests for YAML loading in `internal/loader/yaml_loader_test.go`, covering successful loading, invalid YAML, and empty input.
* Added tests for YAML schema validation in `internal/validator/yaml_validator_test.go`, including valid data, invalid data, and invalid schemas.
* Expanded CLI tests in `cmd/root_test.go` to cover various scenarios, such as missing arguments, file not found, and empty input content.