### PR TITLE
feat: Add multi-file generation with FILE directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+simplate
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,14 +93,17 @@ func runE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read template file '%s': %w", templateFile, err)
 	}
 
+	// Create file writer for FILE directive support
+	fileWriter := &template.DefaultFileWriter{}
+
 	if inputSchemaFile != "" {
 		inputSchemaBytes, err := os.ReadFile(inputSchemaFile)
 		if err != nil {
 			return fmt.Errorf("failed to read schema file '%v': %w", inputSchemaFile, err)
 		}
-		return template.Execute(template.YamlProvider(dataBytes), templateBytes, os.Stdout,
+		return template.ExecuteWithFiles(template.YamlProvider(dataBytes), templateBytes, os.Stdout, fileWriter,
 			template.WithJsonSchemaValidation(inputSchemaBytes))
 	}
 
-	return template.Execute(template.YamlProvider(dataBytes), templateBytes, os.Stdout)
+	return template.ExecuteWithFiles(template.YamlProvider(dataBytes), templateBytes, os.Stdout, fileWriter)
 }

--- a/pkg/template/executor_test.go
+++ b/pkg/template/executor_test.go
@@ -147,3 +147,311 @@ func TestExecute_WithAnyProvider(t *testing.T) {
 		t.Errorf("expected %q, got %q", want, got)
 	}
 }
+
+// TestExecuteWithFiles_NoFileDirectives verifies backward compatibility
+// when template has no FILE directives.
+func TestExecuteWithFiles_NoFileDirectives(t *testing.T) {
+	data := map[string]interface{}{"name": "World"}
+	tmpl := []byte("Hello {{.name}}!")
+	var stdout bytes.Buffer
+	memWriter := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, memWriter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should render to stdout
+	if stdout.String() != "Hello World!" {
+		t.Errorf("expected stdout 'Hello World!', got %q", stdout.String())
+	}
+
+	// Should not create any files
+	if len(memWriter.Files) != 0 {
+		t.Errorf("expected 0 files, got %d", len(memWriter.Files))
+	}
+}
+
+// TestExecuteWithFiles_SingleFile tests basic FILE directive functionality.
+func TestExecuteWithFiles_SingleFile(t *testing.T) {
+	data := map[string]interface{}{"name": "World"}
+	tmpl := []byte("#FILE:output.txt#\nHello {{.name}}!\n#FILE#")
+	var stdout bytes.Buffer
+	memWriter := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, memWriter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Stdout should be empty
+	if stdout.String() != "" {
+		t.Errorf("expected empty stdout, got %q", stdout.String())
+	}
+
+	// Should create one file
+	if len(memWriter.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(memWriter.Files))
+	}
+
+	content, exists := memWriter.Files["output.txt"]
+	if !exists {
+		t.Fatal("expected file 'output.txt' to exist")
+	}
+
+	expected := "\nHello World!\n"
+	if string(content) != expected {
+		t.Errorf("expected file content %q, got %q", expected, content)
+	}
+}
+
+// TestExecuteWithFiles_TemplateFilename tests filename template rendering.
+func TestExecuteWithFiles_TemplateFilename(t *testing.T) {
+	data := map[string]interface{}{"id": "123", "env": "prod"}
+	tmpl := []byte("#FILE:config-{{.env}}-{{.id}}.yml#\nconfig: value\n#FILE#")
+	var stdout bytes.Buffer
+	memWriter := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, memWriter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedFilename := "config-prod-123.yml"
+	content, exists := memWriter.Files[expectedFilename]
+	if !exists {
+		t.Fatalf("expected file %q to exist, got files: %v", expectedFilename, memWriter.Files)
+	}
+
+	if string(content) != "\nconfig: value\n" {
+		t.Errorf("unexpected file content: %q", content)
+	}
+}
+
+// TestExecuteWithFiles_MixedContent tests stdout and FILE segments together.
+func TestExecuteWithFiles_MixedContent(t *testing.T) {
+	data := map[string]interface{}{"msg": "test"}
+	tmpl := []byte("STDOUT: {{.msg}}\n#FILE:file.txt#\nFILE: {{.msg}}\n#FILE#\nMore stdout")
+	var stdout bytes.Buffer
+	memWriter := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, memWriter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check stdout content
+	expectedStdout := "STDOUT: test\n\nMore stdout"
+	if stdout.String() != expectedStdout {
+		t.Errorf("expected stdout %q, got %q", expectedStdout, stdout.String())
+	}
+
+	// Check file content
+	fileContent, exists := memWriter.Files["file.txt"]
+	if !exists {
+		t.Fatal("expected file 'file.txt' to exist")
+	}
+
+	expectedFile := "\nFILE: test\n"
+	if string(fileContent) != expectedFile {
+		t.Errorf("expected file content %q, got %q", expectedFile, fileContent)
+	}
+}
+
+// TestExecuteWithFiles_MultipleFiles tests multiple FILE directives.
+func TestExecuteWithFiles_MultipleFiles(t *testing.T) {
+	data := map[string]interface{}{"app": "myapp"}
+	tmpl := []byte(`#FILE:config.yml#
+app: {{.app}}
+#FILE#
+#FILE:readme.txt#
+App name: {{.app}}
+#FILE#`)
+	var stdout bytes.Buffer
+	memWriter := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, memWriter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(memWriter.Files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(memWriter.Files))
+	}
+
+	// Check config.yml
+	configContent := string(memWriter.Files["config.yml"])
+	if configContent != "\napp: myapp\n" {
+		t.Errorf("unexpected config.yml content: %q", configContent)
+	}
+
+	// Check readme.txt
+	readmeContent := string(memWriter.Files["readme.txt"])
+	if readmeContent != "\nApp name: myapp\n" {
+		t.Errorf("unexpected readme.txt content: %q", readmeContent)
+	}
+}
+
+// TestExecuteWithFiles_WithValidation tests FILE directives with schema validation.
+func TestExecuteWithFiles_WithValidation(t *testing.T) {
+	data := map[string]interface{}{"name": "test"}
+	tmpl := []byte("#FILE:output.txt#\n{{.name}}\n#FILE#")
+	var stdout bytes.Buffer
+	memWriter := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	schema := []byte(`{
+		"type":"object",
+		"properties":{"name":{"type":"string"}},
+		"required":["name"]
+	}`)
+	validate := WithJsonSchemaValidation(schema)
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, memWriter, validate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(memWriter.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(memWriter.Files))
+	}
+}
+
+// TestExecuteWithFiles_ValidationFailure tests that validation errors are caught.
+func TestExecuteWithFiles_ValidationFailure(t *testing.T) {
+	data := map[string]interface{}{"name": 123} // Wrong type
+	tmpl := []byte("#FILE:output.txt#\n{{.name}}\n#FILE#")
+	var stdout bytes.Buffer
+	memWriter := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	schema := []byte(`{
+		"type":"object",
+		"properties":{"name":{"type":"string"}},
+		"required":["name"]
+	}`)
+	validate := WithJsonSchemaValidation(schema)
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, memWriter, validate)
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+}
+
+// TestExecuteWithFiles_InvalidFilename tests error handling for bad filename templates.
+func TestExecuteWithFiles_InvalidFilename(t *testing.T) {
+	data := map[string]interface{}{}
+	// Use invalid template syntax to trigger parse error
+	tmpl := []byte("#FILE:{{.name}#\ncontent\n#FILE#")
+	var stdout bytes.Buffer
+	memWriter := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, memWriter)
+	if err == nil {
+		t.Fatal("expected error for invalid filename template, got nil")
+	}
+}
+
+// TestExecuteWithFiles_WriteError tests error handling when file write fails.
+func TestExecuteWithFiles_WriteError(t *testing.T) {
+	data := map[string]interface{}{"name": "test"}
+	tmpl := []byte("#FILE:output.txt#\ncontent\n#FILE#")
+	var stdout bytes.Buffer
+
+	// Use DefaultFileWriter with path traversal to trigger write error
+	fileWriter := &DefaultFileWriter{}
+	// Create a template with path traversal in rendered filename
+	tmpl = []byte("#FILE:../forbidden.txt#\ncontent\n#FILE#")
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, fileWriter)
+	if err == nil {
+		t.Fatal("expected error for write failure, got nil")
+	}
+}
+
+// TestExecuteWithFiles_DuplicateFilenames tests that duplicate filenames overwrite.
+func TestExecuteWithFiles_DuplicateFilenames(t *testing.T) {
+	data := map[string]interface{}{}
+	tmpl := []byte(`#FILE:same.txt#
+first
+#FILE#
+#FILE:same.txt#
+second
+#FILE#`)
+	var stdout bytes.Buffer
+	memWriter := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, memWriter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Last write should win
+	content := string(memWriter.Files["same.txt"])
+	if content != "\nsecond\n" {
+		t.Errorf("expected last write to win with 'second', got %q", content)
+	}
+}
+
+// TestExecuteWithFiles_EmptyFileContent tests that empty files are created.
+func TestExecuteWithFiles_EmptyFileContent(t *testing.T) {
+	data := map[string]interface{}{}
+	tmpl := []byte("#FILE:empty.txt#\n#FILE#")
+	var stdout bytes.Buffer
+	memWriter := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, memWriter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content, exists := memWriter.Files["empty.txt"]
+	if !exists {
+		t.Fatal("expected empty.txt to exist")
+	}
+
+	// Content should be just the newline
+	if string(content) != "\n" {
+		t.Errorf("expected content '\\n', got %q", content)
+	}
+}
+
+// TestExecuteWithFiles_NestedPath tests file creation with directory paths.
+func TestExecuteWithFiles_NestedPath(t *testing.T) {
+	data := map[string]interface{}{"name": "app"}
+	tmpl := []byte("#FILE:logs/{{.name}}/output.log#\nlog entry\n#FILE#")
+	var stdout bytes.Buffer
+	memWriter := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, memWriter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedPath := "logs/app/output.log"
+	content, exists := memWriter.Files[expectedPath]
+	if !exists {
+		t.Fatalf("expected file %q to exist", expectedPath)
+	}
+
+	if string(content) != "\nlog entry\n" {
+		t.Errorf("unexpected content: %q", content)
+	}
+}
+
+// TestExecuteWithFiles_CustomFunctions tests that custom template functions work in FILE blocks.
+func TestExecuteWithFiles_CustomFunctions(t *testing.T) {
+	data := map[string]interface{}{"items": []interface{}{"a", "b", "a", "c"}}
+	tmpl := []byte("#FILE:unique.txt#\n{{unique .items}}\n#FILE#")
+	var stdout bytes.Buffer
+	memWriter := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	err := ExecuteWithFiles(AnyProvider(data), tmpl, &stdout, memWriter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content := string(memWriter.Files["unique.txt"])
+	// unique function should deduplicate the array
+	if content != "\n[a b c]\n" {
+		t.Errorf("expected unique items, got %q", content)
+	}
+}

--- a/pkg/template/parser.go
+++ b/pkg/template/parser.go
@@ -1,0 +1,189 @@
+package template
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// SegmentType represents the type of template segment.
+type SegmentType int
+
+const (
+	// SegmentStdout indicates content that should be written to stdout.
+	SegmentStdout SegmentType = iota
+	// SegmentFile indicates content that should be written to a file.
+	SegmentFile
+)
+
+// Segment represents a portion of a template that is either directed to stdout
+// or to a specific file.
+type Segment struct {
+	Type     SegmentType
+	Content  []byte // Raw template content to be rendered
+	Filename []byte // Template expression for filename (FILE segments only)
+}
+
+const (
+	fileOpenPrefix = "#FILE:"
+	fileOpenSuffix = "#"
+	fileClose      = "#FILE#"
+)
+
+// ParseSegments parses a template into segments based on FILE directive markers.
+// It identifies #FILE:filename# ... #FILE# blocks and separates them from
+// content that should go to stdout.
+//
+// Returns a slice of Segment objects representing the parsed template, or an
+// error if the template contains malformed FILE directives.
+//
+// Error conditions:
+//   - Unclosed FILE directive (missing closing #FILE#)
+//   - Nested FILE directives (FILE directive inside another FILE directive)
+//   - Empty filename in FILE directive
+func ParseSegments(templateBytes []byte) ([]Segment, error) {
+	if len(templateBytes) == 0 {
+		return []Segment{{Type: SegmentStdout, Content: []byte{}}}, nil
+	}
+
+	var segments []Segment
+	template := string(templateBytes)
+	pos := 0
+	inFileBlock := false
+	fileBlockStart := 0
+
+	for pos < len(template) {
+		// Look for FILE directive markers
+		openIdx := strings.Index(template[pos:], fileOpenPrefix)
+		closeIdx := strings.Index(template[pos:], fileClose)
+
+		// No more directives found
+		if openIdx == -1 && closeIdx == -1 {
+			if inFileBlock {
+				return nil, fmt.Errorf("unclosed FILE directive starting at position %d", fileBlockStart)
+			}
+			// Add remaining content as stdout segment
+			if pos < len(template) {
+				segments = append(segments, Segment{
+					Type:    SegmentStdout,
+					Content: []byte(template[pos:]),
+				})
+			}
+			break
+		}
+
+		if !inFileBlock {
+			// We're looking for an opening directive
+			if closeIdx != -1 && (openIdx == -1 || closeIdx < openIdx) {
+				return nil, fmt.Errorf("unexpected FILE closing marker at position %d", pos+closeIdx)
+			}
+
+			if openIdx != -1 {
+				// Found opening directive
+				// Add any content before this as stdout segment
+				if openIdx > 0 {
+					segments = append(segments, Segment{
+						Type:    SegmentStdout,
+						Content: []byte(template[pos : pos+openIdx]),
+					})
+				}
+
+				// Find the end of the opening marker (the second #)
+				openStart := pos + openIdx
+				filenameStart := openStart + len(fileOpenPrefix)
+				filenameEnd := strings.Index(template[filenameStart:], fileOpenSuffix)
+
+				if filenameEnd == -1 {
+					return nil, fmt.Errorf("malformed FILE directive at position %d: missing closing # in filename", openStart)
+				}
+
+				filename := template[filenameStart : filenameStart+filenameEnd]
+				if strings.TrimSpace(filename) == "" {
+					return nil, fmt.Errorf("empty filename in FILE directive at position %d", openStart)
+				}
+
+				// Check for nested FILE directive in filename
+				if strings.Contains(filename, fileOpenPrefix) {
+					return nil, fmt.Errorf("nested FILE directive not allowed at position %d", openStart)
+				}
+
+				fileBlockStart = openStart
+				inFileBlock = true
+				pos = filenameStart + filenameEnd + len(fileOpenSuffix)
+
+				// Store filename for later when we find the closing marker
+				segments = append(segments, Segment{
+					Type:     SegmentFile,
+					Filename: []byte(filename),
+					Content:  nil, // Will be filled when we find the closing marker
+				})
+			}
+		} else {
+			// We're inside a FILE block, looking for closing directive
+			if openIdx != -1 && (closeIdx == -1 || openIdx < closeIdx) {
+				return nil, fmt.Errorf("nested FILE directive not allowed at position %d", pos+openIdx)
+			}
+
+			if closeIdx != -1 {
+				// Found closing directive
+				// Extract content between opening and closing
+				content := template[pos : pos+closeIdx]
+				segments[len(segments)-1].Content = []byte(content)
+
+				inFileBlock = false
+				pos = pos + closeIdx + len(fileClose)
+			} else {
+				return nil, fmt.Errorf("unclosed FILE directive starting at position %d", fileBlockStart)
+			}
+		}
+	}
+
+	if inFileBlock {
+		return nil, fmt.Errorf("unclosed FILE directive starting at position %d", fileBlockStart)
+	}
+
+	// If no segments were created, return a single stdout segment with all content
+	if len(segments) == 0 {
+		return []Segment{{Type: SegmentStdout, Content: templateBytes}}, nil
+	}
+
+	// Filter out empty stdout segments at the beginning and end
+	return filterEmptyEdgeSegments(segments), nil
+}
+
+// filterEmptyEdgeSegments removes empty stdout segments from the beginning
+// and end of the segments slice, but preserves empty segments in the middle
+// and all FILE segments (even if empty).
+func filterEmptyEdgeSegments(segments []Segment) []Segment {
+	if len(segments) == 0 {
+		return segments
+	}
+
+	start := 0
+	end := len(segments)
+
+	// Find first non-empty segment or first FILE segment
+	for start < len(segments) {
+		seg := segments[start]
+		if seg.Type == SegmentFile || len(bytes.TrimSpace(seg.Content)) > 0 {
+			break
+		}
+		start++
+	}
+
+	// Find last non-empty segment or last FILE segment
+	for end > start {
+		seg := segments[end-1]
+		if seg.Type == SegmentFile || len(bytes.TrimSpace(seg.Content)) > 0 {
+			break
+		}
+		end--
+	}
+
+	if start >= end {
+		// All segments were empty stdout segments
+		return []Segment{{Type: SegmentStdout, Content: []byte{}}}
+	}
+
+	return segments[start:end]
+}

--- a/pkg/template/parser_test.go
+++ b/pkg/template/parser_test.go
@@ -1,0 +1,295 @@
+package template
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSegments_EmptyTemplate(t *testing.T) {
+	segments, err := ParseSegments([]byte{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segments))
+	}
+	if segments[0].Type != SegmentStdout {
+		t.Errorf("expected SegmentStdout, got %v", segments[0].Type)
+	}
+	if len(segments[0].Content) != 0 {
+		t.Errorf("expected empty content, got %q", segments[0].Content)
+	}
+}
+
+func TestParseSegments_SingleStdout(t *testing.T) {
+	template := []byte("Hello {{.name}}")
+	segments, err := ParseSegments(template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segments))
+	}
+	if segments[0].Type != SegmentStdout {
+		t.Errorf("expected SegmentStdout, got %v", segments[0].Type)
+	}
+	if !reflect.DeepEqual(segments[0].Content, template) {
+		t.Errorf("expected content %q, got %q", template, segments[0].Content)
+	}
+}
+
+func TestParseSegments_SingleFile(t *testing.T) {
+	template := []byte("#FILE:output.txt#\nHello {{.name}}\n#FILE#")
+	segments, err := ParseSegments(template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segments))
+	}
+	if segments[0].Type != SegmentFile {
+		t.Errorf("expected SegmentFile, got %v", segments[0].Type)
+	}
+	if string(segments[0].Filename) != "output.txt" {
+		t.Errorf("expected filename 'output.txt', got %q", segments[0].Filename)
+	}
+	expectedContent := "\nHello {{.name}}\n"
+	if string(segments[0].Content) != expectedContent {
+		t.Errorf("expected content %q, got %q", expectedContent, segments[0].Content)
+	}
+}
+
+func TestParseSegments_FileWithTemplateFilename(t *testing.T) {
+	template := []byte("#FILE:output-{{.id}}.txt#\ncontent\n#FILE#")
+	segments, err := ParseSegments(template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segments))
+	}
+	if string(segments[0].Filename) != "output-{{.id}}.txt" {
+		t.Errorf("expected filename 'output-{{.id}}.txt', got %q", segments[0].Filename)
+	}
+}
+
+func TestParseSegments_MixedContent(t *testing.T) {
+	template := []byte("Stdout content\n#FILE:file.txt#\nFile content\n#FILE#\nMore stdout")
+	segments, err := ParseSegments(template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segments) != 3 {
+		t.Fatalf("expected 3 segments, got %d", len(segments))
+	}
+
+	// First segment: stdout
+	if segments[0].Type != SegmentStdout {
+		t.Errorf("segment 0: expected SegmentStdout, got %v", segments[0].Type)
+	}
+	if string(segments[0].Content) != "Stdout content\n" {
+		t.Errorf("segment 0: expected 'Stdout content\\n', got %q", segments[0].Content)
+	}
+
+	// Second segment: file
+	if segments[1].Type != SegmentFile {
+		t.Errorf("segment 1: expected SegmentFile, got %v", segments[1].Type)
+	}
+	if string(segments[1].Filename) != "file.txt" {
+		t.Errorf("segment 1: expected filename 'file.txt', got %q", segments[1].Filename)
+	}
+	if string(segments[1].Content) != "\nFile content\n" {
+		t.Errorf("segment 1: expected '\\nFile content\\n', got %q", segments[1].Content)
+	}
+
+	// Third segment: stdout
+	if segments[2].Type != SegmentStdout {
+		t.Errorf("segment 2: expected SegmentStdout, got %v", segments[2].Type)
+	}
+	if string(segments[2].Content) != "\nMore stdout" {
+		t.Errorf("segment 2: expected '\\nMore stdout', got %q", segments[2].Content)
+	}
+}
+
+func TestParseSegments_MultipleFiles(t *testing.T) {
+	template := []byte("#FILE:first.txt#\nFirst\n#FILE#\n#FILE:second.txt#\nSecond\n#FILE#")
+	segments, err := ParseSegments(template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// There will be 3 segments: file, stdout (the \n between files), file
+	if len(segments) != 3 {
+		t.Fatalf("expected 3 segments, got %d", len(segments))
+	}
+
+	if segments[0].Type != SegmentFile || string(segments[0].Filename) != "first.txt" {
+		t.Errorf("segment 0: expected file 'first.txt', got type=%v filename=%q", segments[0].Type, segments[0].Filename)
+	}
+	if segments[1].Type != SegmentStdout {
+		t.Errorf("segment 1: expected stdout segment between files, got type=%v", segments[1].Type)
+	}
+	if segments[2].Type != SegmentFile || string(segments[2].Filename) != "second.txt" {
+		t.Errorf("segment 2: expected file 'second.txt', got type=%v filename=%q", segments[2].Type, segments[2].Filename)
+	}
+}
+
+func TestParseSegments_EmptyFileContent(t *testing.T) {
+	template := []byte("#FILE:empty.txt#\n#FILE#")
+	segments, err := ParseSegments(template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segments))
+	}
+	if segments[0].Type != SegmentFile {
+		t.Errorf("expected SegmentFile, got %v", segments[0].Type)
+	}
+	if string(segments[0].Filename) != "empty.txt" {
+		t.Errorf("expected filename 'empty.txt', got %q", segments[0].Filename)
+	}
+	// Content should be just the newline between markers
+	if string(segments[0].Content) != "\n" {
+		t.Errorf("expected content '\\n', got %q", segments[0].Content)
+	}
+}
+
+func TestParseSegments_UnclosedBlock(t *testing.T) {
+	template := []byte("#FILE:output.txt#\nContent without closing")
+	_, err := ParseSegments(template)
+	if err == nil {
+		t.Fatal("expected error for unclosed FILE block, got nil")
+	}
+	if !contains(err.Error(), "unclosed FILE directive") {
+		t.Errorf("expected 'unclosed FILE directive' error, got: %v", err)
+	}
+}
+
+func TestParseSegments_MissingFilename(t *testing.T) {
+	template := []byte("#FILE:#\ncontent\n#FILE#")
+	_, err := ParseSegments(template)
+	if err == nil {
+		t.Fatal("expected error for empty filename, got nil")
+	}
+	if !contains(err.Error(), "empty filename") {
+		t.Errorf("expected 'empty filename' error, got: %v", err)
+	}
+}
+
+func TestParseSegments_MalformedOpeningMarker(t *testing.T) {
+	template := []byte("#FILE:filename\ncontent\n#FILE#")
+	_, err := ParseSegments(template)
+	if err == nil {
+		t.Fatal("expected error for malformed FILE directive, got nil")
+	}
+	// This will be detected as unclosed since the opening marker is never properly closed with #
+	if !contains(err.Error(), "unclosed FILE directive") && !contains(err.Error(), "malformed FILE directive") {
+		t.Errorf("expected 'unclosed FILE directive' or 'malformed FILE directive' error, got: %v", err)
+	}
+}
+
+func TestParseSegments_NestedBlocks(t *testing.T) {
+	template := []byte("#FILE:outer.txt#\n#FILE:inner.txt#\nNested\n#FILE#\n#FILE#")
+	_, err := ParseSegments(template)
+	if err == nil {
+		t.Fatal("expected error for nested FILE blocks, got nil")
+	}
+	if !contains(err.Error(), "nested FILE directive") {
+		t.Errorf("expected 'nested FILE directive' error, got: %v", err)
+	}
+}
+
+func TestParseSegments_UnexpectedClosingMarker(t *testing.T) {
+	template := []byte("Some content\n#FILE#\n")
+	_, err := ParseSegments(template)
+	if err == nil {
+		t.Fatal("expected error for unexpected closing marker, got nil")
+	}
+	if !contains(err.Error(), "unexpected FILE closing marker") {
+		t.Errorf("expected 'unexpected FILE closing marker' error, got: %v", err)
+	}
+}
+
+func TestParseSegments_WhitespaceOnly(t *testing.T) {
+	template := []byte("   \n\t\n   ")
+	segments, err := ParseSegments(template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should be filtered to empty stdout segment
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segments))
+	}
+	if segments[0].Type != SegmentStdout {
+		t.Errorf("expected SegmentStdout, got %v", segments[0].Type)
+	}
+}
+
+func TestParseSegments_FileWithPathSeparators(t *testing.T) {
+	template := []byte("#FILE:output/nested/file.txt#\ncontent\n#FILE#")
+	segments, err := ParseSegments(template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segments))
+	}
+	if string(segments[0].Filename) != "output/nested/file.txt" {
+		t.Errorf("expected filename 'output/nested/file.txt', got %q", segments[0].Filename)
+	}
+}
+
+func TestParseSegments_ComplexMixedContent(t *testing.T) {
+	template := []byte(`Start of template
+#FILE:config-{{.env}}.yml#
+config: {{.config}}
+#FILE#
+Middle content
+#FILE:logs/{{.name}}.log#
+log entry
+#FILE#
+End of template`)
+
+	segments, err := ParseSegments(template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segments) != 5 {
+		t.Fatalf("expected 5 segments, got %d", len(segments))
+	}
+
+	// Validate segment types and filenames
+	expected := []struct {
+		typ      SegmentType
+		filename string
+	}{
+		{SegmentStdout, ""},
+		{SegmentFile, "config-{{.env}}.yml"},
+		{SegmentStdout, ""},
+		{SegmentFile, "logs/{{.name}}.log"},
+		{SegmentStdout, ""},
+	}
+
+	for i, exp := range expected {
+		if segments[i].Type != exp.typ {
+			t.Errorf("segment %d: expected type %v, got %v", i, exp.typ, segments[i].Type)
+		}
+		if exp.typ == SegmentFile && string(segments[i].Filename) != exp.filename {
+			t.Errorf("segment %d: expected filename %q, got %q", i, exp.filename, segments[i].Filename)
+		}
+	}
+}
+
+// Helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && containsAny(s, substr))
+}
+
+func containsAny(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/template/writer.go
+++ b/pkg/template/writer.go
@@ -1,0 +1,87 @@
+package template
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FileWriter provides an abstraction for writing files to enable testing
+// without actual filesystem I/O.
+type FileWriter interface {
+	WriteFile(filename string, content []byte) error
+}
+
+// DefaultFileWriter is the production implementation of FileWriter that writes
+// files to the actual filesystem.
+type DefaultFileWriter struct{}
+
+// WriteFile writes content to the specified filename, creating parent directories
+// as needed. It performs atomic writes using a temporary file and rename strategy
+// to prevent partial writes on error.
+//
+// Security considerations:
+//   - Filenames are sanitized using filepath.Clean()
+//   - Path traversal attempts (containing "..") are rejected
+//   - Parent directories are created with 0755 permissions
+//   - Files are created with 0644 permissions
+func (w *DefaultFileWriter) WriteFile(filename string, content []byte) error {
+	if filename == "" {
+		return fmt.Errorf("filename cannot be empty")
+	}
+
+	// Check for path traversal attempts before cleaning
+	// This catches patterns like "../" or "..\\"
+	if strings.Contains(filename, "..") {
+		return fmt.Errorf("path traversal not allowed in filename: %s", filename)
+	}
+
+	// Sanitize filename
+	cleanFilename := filepath.Clean(filename)
+
+	// Get directory path
+	dir := filepath.Dir(cleanFilename)
+
+	// Create parent directories if needed
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+
+	// Write to temporary file first for atomic write
+	tmpFile := cleanFilename + ".tmp"
+	if err := os.WriteFile(tmpFile, content, 0644); err != nil {
+		return fmt.Errorf("failed to write file %s: %w", cleanFilename, err)
+	}
+
+	// Rename temporary file to final filename (atomic on most filesystems)
+	if err := os.Rename(tmpFile, cleanFilename); err != nil {
+		os.Remove(tmpFile) // Clean up temp file on error
+		return fmt.Errorf("failed to rename temp file to %s: %w", cleanFilename, err)
+	}
+
+	return nil
+}
+
+// MemoryFileWriter is a test implementation of FileWriter that stores files
+// in memory rather than writing to the filesystem. This enables fast, isolated
+// testing without filesystem side effects.
+type MemoryFileWriter struct {
+	Files map[string][]byte
+}
+
+// WriteFile stores the content in memory under the given filename.
+func (w *MemoryFileWriter) WriteFile(filename string, content []byte) error {
+	if filename == "" {
+		return fmt.Errorf("filename cannot be empty")
+	}
+
+	if w.Files == nil {
+		w.Files = make(map[string][]byte)
+	}
+
+	w.Files[filename] = content
+	return nil
+}

--- a/pkg/template/writer_test.go
+++ b/pkg/template/writer_test.go
@@ -1,0 +1,244 @@
+package template
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMemoryFileWriter_WriteFile(t *testing.T) {
+	writer := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	content := []byte("test content")
+	err := writer.WriteFile("test.txt", content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(writer.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(writer.Files))
+	}
+
+	storedContent, exists := writer.Files["test.txt"]
+	if !exists {
+		t.Fatal("expected file 'test.txt' to exist")
+	}
+
+	if string(storedContent) != string(content) {
+		t.Errorf("expected content %q, got %q", content, storedContent)
+	}
+}
+
+func TestMemoryFileWriter_EmptyFilename(t *testing.T) {
+	writer := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	err := writer.WriteFile("", []byte("content"))
+	if err == nil {
+		t.Fatal("expected error for empty filename, got nil")
+	}
+}
+
+func TestMemoryFileWriter_MultipleFiles(t *testing.T) {
+	writer := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	files := map[string][]byte{
+		"file1.txt": []byte("content 1"),
+		"file2.txt": []byte("content 2"),
+		"file3.txt": []byte("content 3"),
+	}
+
+	for filename, content := range files {
+		if err := writer.WriteFile(filename, content); err != nil {
+			t.Fatalf("unexpected error writing %s: %v", filename, err)
+		}
+	}
+
+	if len(writer.Files) != len(files) {
+		t.Fatalf("expected %d files, got %d", len(files), len(writer.Files))
+	}
+
+	for filename, expectedContent := range files {
+		storedContent, exists := writer.Files[filename]
+		if !exists {
+			t.Errorf("expected file %s to exist", filename)
+			continue
+		}
+		if string(storedContent) != string(expectedContent) {
+			t.Errorf("file %s: expected content %q, got %q", filename, expectedContent, storedContent)
+		}
+	}
+}
+
+func TestMemoryFileWriter_Overwrite(t *testing.T) {
+	writer := &MemoryFileWriter{Files: make(map[string][]byte)}
+
+	writer.WriteFile("test.txt", []byte("first"))
+	writer.WriteFile("test.txt", []byte("second"))
+
+	if string(writer.Files["test.txt"]) != "second" {
+		t.Errorf("expected file to be overwritten with 'second', got %q", writer.Files["test.txt"])
+	}
+}
+
+func TestDefaultFileWriter_WriteFile(t *testing.T) {
+	// Create temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "simplate-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	writer := &DefaultFileWriter{}
+	filename := filepath.Join(tmpDir, "test.txt")
+	content := []byte("test content")
+
+	err = writer.WriteFile(filename, content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify file was created
+	storedContent, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("failed to read created file: %v", err)
+	}
+
+	if string(storedContent) != string(content) {
+		t.Errorf("expected content %q, got %q", content, storedContent)
+	}
+
+	// Verify file permissions
+	info, err := os.Stat(filename)
+	if err != nil {
+		t.Fatalf("failed to stat file: %v", err)
+	}
+
+	expectedPerms := os.FileMode(0644)
+	if info.Mode().Perm() != expectedPerms {
+		t.Errorf("expected permissions %v, got %v", expectedPerms, info.Mode().Perm())
+	}
+}
+
+func TestDefaultFileWriter_DirectoryCreation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "simplate-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	writer := &DefaultFileWriter{}
+	filename := filepath.Join(tmpDir, "subdir", "nested", "test.txt")
+	content := []byte("nested content")
+
+	err = writer.WriteFile(filename, content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify file was created
+	storedContent, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("failed to read created file: %v", err)
+	}
+
+	if string(storedContent) != string(content) {
+		t.Errorf("expected content %q, got %q", content, storedContent)
+	}
+
+	// Verify directories were created
+	dirInfo, err := os.Stat(filepath.Join(tmpDir, "subdir", "nested"))
+	if err != nil {
+		t.Fatalf("failed to stat created directory: %v", err)
+	}
+
+	if !dirInfo.IsDir() {
+		t.Error("expected nested path to be a directory")
+	}
+}
+
+func TestDefaultFileWriter_EmptyFilename(t *testing.T) {
+	writer := &DefaultFileWriter{}
+
+	err := writer.WriteFile("", []byte("content"))
+	if err == nil {
+		t.Fatal("expected error for empty filename, got nil")
+	}
+}
+
+func TestDefaultFileWriter_PathTraversal(t *testing.T) {
+	writer := &DefaultFileWriter{}
+
+	// Try various path traversal attempts (relative paths with ..)
+	pathTraversalAttempts := []string{
+		"../../../etc/passwd",
+		"subdir/../../outside.txt",
+		"./subdir/../../../etc/passwd",
+		"test/../../../dangerous.txt",
+	}
+
+	for _, filename := range pathTraversalAttempts {
+		err := writer.WriteFile(filename, []byte("malicious"))
+		if err == nil {
+			t.Errorf("expected error for path traversal attempt %q, got nil", filename)
+		}
+		if err != nil && !contains(err.Error(), "path traversal") {
+			t.Errorf("expected 'path traversal' error for %q, got: %v", filename, err)
+		}
+	}
+}
+
+func TestDefaultFileWriter_AtomicWrite(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "simplate-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	writer := &DefaultFileWriter{}
+	filename := filepath.Join(tmpDir, "atomic.txt")
+
+	// Write file
+	err = writer.WriteFile(filename, []byte("content"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify temp file was cleaned up
+	tmpFile := filename + ".tmp"
+	if _, err := os.Stat(tmpFile); !os.IsNotExist(err) {
+		t.Error("expected temp file to be cleaned up")
+	}
+}
+
+func TestDefaultFileWriter_Overwrite(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "simplate-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	writer := &DefaultFileWriter{}
+	filename := filepath.Join(tmpDir, "overwrite.txt")
+
+	// Write first version
+	err = writer.WriteFile(filename, []byte("first"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Overwrite with second version
+	err = writer.WriteFile(filename, []byte("second"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify final content
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+
+	if string(content) != "second" {
+		t.Errorf("expected content 'second', got %q", content)
+	}
+}


### PR DESCRIPTION
Implements multi-file generation support using FILE directives in templates. This allows generating multiple files from a single template with dynamic filenames and content.

Features:
- FILE directive syntax: #FILE:filename# ... #FILE#
- Template-rendered filenames (e.g., #FILE:config-{{.env}}.yml#)
- Multiple file generation from a single template
- Auto-creation of parent directories
- Mixed output: stdout + files in one template
- Full backward compatibility with templates without FILE directives
- Path traversal protection for security
- Atomic file writes using temp file + rename

Implementation:
- pkg/template/parser.go: Parse FILE directives into segments
- pkg/template/writer.go: FileWriter interface with Default/Memory implementations
- pkg/template/executor.go: Added ExecuteWithFiles() function
- cmd/root.go: Updated CLI to use ExecuteWithFiles

Testing:
- 38 new tests covering parser, writer, and integration scenarios
- Manual testing verified with real file generation
- All existing tests pass (backward compatibility confirmed)

Documentation:
- README.md: Comprehensive examples and usage guide
- API documentation for library usage
- Security considerations documented